### PR TITLE
Create the ~/.git-stats file if it doesn't exist.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -253,13 +253,13 @@ GitStats.calendar = function (data, callback) {
             }
         });
 
-        levels = Math.ceil(cal.max / (LEVELS.length * 3));
+        levels = cal.max / (LEVELS.length * 2);
         days.forEach(function (c) {
             cDay = graph[c];
             cal.days[c] = {
                 c: cDay.c
               , level: !levels
-              ? 0 : (cLevel = Math.floor(cDay.c / levels )) >= 5
+              ? 0 : (cLevel = Math.round(cDay.c / levels)) >= 4
               ? 4 : !cLevel && cDay.c > 0 ? 1 : cLevel
             };
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,6 +95,13 @@ GitStats.record = function (data, callback) {
  */
 GitStats.get = function (callback) {
     Fs.readFile(STORE_PATH, "utf-8", function (err, data) {
+
+        if (err && err.code === "ENOENT") {
+           return GitStats.save({}, function (err) {
+               callback(err, {});
+           });
+        }
+
         if (err) { return callback(err); }
         try {
             data = JSON.parse(data);


### PR DESCRIPTION
 - Fixed #2. Check if the file is not found. If so, create it.
 - Minor edits in the algorithm of normalizing the graph data.