### PR TITLE
Month label position fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -287,12 +287,13 @@ GitStats.ansiCalendar = function (data, callback) {
     }
 
     var year = []
-      , months = []
+      , months = new Array(52) // Stores the months depending on their first week
       , cWeek = [" ", " ", " ", " ", " ", " ", " "]
       , monthHack = "MM"
       , sDay = ""
       , cDayObj = null
       , strYear = ""
+      , strMonths = ""
       , w = 0
       , d = 0
       , dataClone = {
@@ -305,9 +306,6 @@ GitStats.ansiCalendar = function (data, callback) {
         if (err) { return callback(err); }
         GitStats.iterateDays(dataClone, function (cDay, mDay) {
             sDay = mDay.format("ddd");
-            if (mDay.format("D") === "1") {
-                months.push(mDay.format("MMM"));
-            }
 
             cDayObj = cal.days[cDay];
             if (!cDayObj) return;
@@ -315,6 +313,11 @@ GitStats.ansiCalendar = function (data, callback) {
             if (sDay === "Sun" && Object.keys(cWeek).length) {
                 year.push(cWeek);
                 cWeek = [" ", " ", " ", " ", " ", " ", " "];
+            }
+
+            // Store the new month this week
+            if (mDay.format("D") === "1") {
+                months[year.length] = mDay.format("MMM");
             }
 
             cWeek[DAYS.indexOf(sDay)] = LEVELS[cDayObj.level];
@@ -337,8 +340,14 @@ GitStats.ansiCalendar = function (data, callback) {
             return DAYS[i] + c;
         }).join("\n");
 
-        monthHack = "MMM";
-        strYear = monthHack + months.join("      ") + "\n" + strYear;
+        // Months label
+        monthHack = "MMMM"; //Left padding
+        for (var i=0; i<months.length; i++) {
+          // The length of strMonths should always be 2*(i+1) (at the i-th column)
+          if (months[i] === undefined) strMonths += new Array(2*(i+1)-strMonths.length+1).join(" ");
+          else strMonths += months[i];
+        }
+        strYear = monthHack + strMonths + "\n" + strYear;
         strYear +=
              new Array(5 + 2 * Math.ceil(365 / 7)).join("-")
           + "\n" + "Contributions in the last year: " + cal.total

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "test": "node test"
   },
   "author": "Ionică Bizău <bizauionica@gmail.com>",
+  "contributors": [
+    "Gnab <as0n@gnab.fr>"
+  ],
   "license": "MIT",
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
This fixes issue #21 : it displays the month labels neatly above the first week.

See this before/after example : 
![git-stats](https://cloud.githubusercontent.com/assets/3386177/6236994/77b94264-b6ef-11e4-8a07-328105847e4d.png "Top : before changes, Bottom : after changes, notive how the labels are right above the first week of the month")
Notive how the labels are right above the first week of the month.

I changed the way the `month` array of `GitStats.ansiCalendar` is used and made it fixed-length (52) : it now stores the label of the month starting for each week/column. I also added the `strMonths` variable, which is constructed by concatenating month labels (for the first weeks of each month) and spaces (for the others).

I've tested this patch without arguments and with various start/end dates and it always seem to display an appropriate result.
Let me know if there's something I should change !