### PR TITLE
Improve init git hook script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "author": "Ionică Bizău <bizauionica@gmail.com>",
   "contributors": [
-    "Gnab <as0n@gnab.fr>"
+    "Gnab <as0n@gnab.fr>",
+    "William Boman <william@redwill.se>"
   ],
   "license": "MIT",
   "devDependencies": {},

--- a/scripts/init-git-post-commit
+++ b/scripts/init-git-post-commit
@@ -1,21 +1,32 @@
 #!/bin/sh
 
-git_templates_dir="$HOME/.git-templates"
-git_hooks_dir="$git_templates_dir/hooks"
-post_commit_path="$git_hooks_dir/post-commit"
+git_templates_dir=$(git config --global --get init.templatedir);
+if [ $? -ne 0 ]; then
+	# Create a new global templatedir if there are none
+	git_templates_dir="${HOME}/.git-templates"
+	git config --global init.templatedir "$git_templates_dir"
+fi
+git_hooks_dir="${git_templates_dir}/hooks"
+post_commit_path="${git_hooks_dir}/post-commit"
 
-git config --global init.templatedir $git_templates_dir
-mkdir -p $git_hooks_dir
+mkdir -p "$git_hooks_dir"
 
-cat << EOF > $post_commit_path
-#!/bin/sh
+hook=$(cat <<EOF
 
+### git-stats hook (begin) ###
 # Copy last commit hash to clipboard on commit
 commit_hash=\`git rev-parse HEAD\`
 repo_url=\`git config --get remote.origin.url\`
 commit_date=\`git log -1 --format=%cd\`
 commit_data="\"{ \"date\": \"\$commit_date\", \"url\": \"\$repo_url\", \"hash\": \"\$commit_hash\" }\""
 git-stats --record "\$commit_data"
+### git-stats hook (end) ###
 EOF
+);
 
-chmod +x $post_commit_path
+if [ ! -f "$post_commit_path" ]; then
+	printf "#!/bin/sh\n%s" "$hook" > "$post_commit_path"
+	chmod +x "$post_commit_path"
+else
+	printf "\n%s\n" "$hook" >> "$post_commit_path"
+fi

--- a/scripts/init-git-post-commit
+++ b/scripts/init-git-post-commit
@@ -1,10 +1,12 @@
 #!/bin/sh
 
+echo "Setting up git-stats hooks.";
+
 git_templates_dir=$(git config --global --get init.templatedir);
 if [ $? -ne 0 ]; then
 	# Create a new global templatedir if there are none
 	git_templates_dir="${HOME}/.git-templates"
-	git config --global init.templatedir "$git_templates_dir"
+	git config --global init.templatedir "$git_templates_dir" && echo "Set new global git template dir at ${git_templates_dir}"
 fi
 git_hooks_dir="${git_templates_dir}/hooks"
 post_commit_path="${git_hooks_dir}/post-commit"
@@ -25,8 +27,15 @@ EOF
 );
 
 if [ ! -f "$post_commit_path" ]; then
-	printf "#!/bin/sh\n%s" "$hook" > "$post_commit_path"
-	chmod +x "$post_commit_path"
+	printf "#!/bin/sh\n%s" "$hook" > "$post_commit_path" \
+		&& chmod +x "$post_commit_path" \
+		&& echo "Successfully set up git-stats hook at ${post_commit_path}." \
+		&& exit 0
 else
-	printf "\n%s\n" "$hook" >> "$post_commit_path"
+	printf "\n%s\n" "$hook" >> "$post_commit_path" \
+		&& echo "Successfully set up git-stats hook at ${post_commit_path}." \
+		&& exit 0
 fi
+
+echo "Couldn't set up git-stats hook."
+exit 1

--- a/scripts/init-git-post-commit
+++ b/scripts/init-git-post-commit
@@ -17,9 +17,9 @@ hook=$(cat <<EOF
 
 ### git-stats hook (begin) ###
 # Copy last commit hash to clipboard on commit
-commit_hash=\`git rev-parse HEAD\`
-repo_url=\`git config --get remote.origin.url\`
-commit_date=\`git log -1 --format=%cd\`
+commit_hash=\$(git rev-parse HEAD)
+repo_url=\$(git config --get remote.origin.url)
+commit_date=\$(git log -1 --format=%cd)
 commit_data="\"{ \"date\": \"\$commit_date\", \"url\": \"\$repo_url\", \"hash\": \"\$commit_hash\" }\""
 git-stats --record "\$commit_data"
 ### git-stats hook (end) ###

--- a/scripts/init-git-post-commit
+++ b/scripts/init-git-post-commit
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+check_command() {
+	command -v "$1" > /dev/null 2>&1 || { echo "git-stats hook script requires the \`${1}\` binary in order to run." >&2; exit 1; }
+}
+
+check_command "perl"
+check_command "printf"
+check_command "git"
+
 echo "Setting up git-stats hooks.";
 
 git_templates_dir=$(git config --global --get init.templatedir);

--- a/scripts/init-git-post-commit
+++ b/scripts/init-git-post-commit
@@ -22,14 +22,13 @@ post_commit_path="${git_hooks_dir}/post-commit"
 mkdir -p "$git_hooks_dir"
 
 hook=$(cat <<EOF
-
 ### git-stats hook (begin) ###
 # Copy last commit hash to clipboard on commit
 commit_hash=\$(git rev-parse HEAD)
 repo_url=\$(git config --get remote.origin.url)
 commit_date=\$(git log -1 --format=%cd)
 commit_data="\"{ \"date\": \"\$commit_date\", \"url\": \"\$repo_url\", \"hash\": \"\$commit_hash\" }\""
-git-stats --record "\$commit_data"
+git-stats --record "\${commit_data}"
 ### git-stats hook (end) ###
 EOF
 );
@@ -40,6 +39,8 @@ if [ ! -f "$post_commit_path" ]; then
 		&& echo "Successfully set up git-stats hook at ${post_commit_path}." \
 		&& exit 0
 else
+	# Remove any previous git-stats hook code blocks
+	perl -i -0pe 's/(([ \t]*# Copy last commit hash to clipboard on commit\s*(\n.*){5}\s*git-stats --record "\$commit_data"\s*)|([ \t]*### git-stats hook \(begin\) ###\s*(\n.*){7}\s*### git-stats hook \(end\) ###\s*))//g' "$post_commit_path"
 	printf "\n%s\n" "$hook" >> "$post_commit_path" \
 		&& echo "Successfully set up git-stats hook at ${post_commit_path}." \
 		&& exit 0


### PR DESCRIPTION
- Prevent word splitting
- Only create new global templatedir if it's missing
- Append our hook script if hook file already exists.