### PR TITLE
Setting first day

### DIFF
--- a/bin/git-stats
+++ b/bin/git-stats
@@ -10,8 +10,6 @@ var GitStats = new (require("../lib"))()
   ;
 
 // Configurations
-Logger.config.displayDate = false;
-Logger.config.logLevel = 4;
 Moment.suppressDeprecationWarnings = true;
 
 // Parse the command line arguments
@@ -22,7 +20,8 @@ var recordOpt = new CLP.Option(["record"], "Records a new commit. Don't use this
   , noAnsiOpt = new CLP.Option(["n", "no-ansi"], "Forces the tool not to use ANSI styles.")
   , lightOpt = new CLP.Option(["l", "light"], "Enables the light theme.")
   , configPathOpt = new CLP.Option(["c", "config"], "Sets a custom config file.", "path")
-  , globalActivityOpt = new CLP.Option(["g", "global-activyt"], "Shows global activity calendar in the current repository.")
+  , globalActivityOpt = new CLP.Option(["g", "global-activity"], "Shows global activity calendar in the current repository.")
+  , firstDayOpt = new CLP.Option(["d", "first-day"], "Sets the first day of the week.", "day", "Sun")
   , parser = new CLP({
         name: "Git Stats"
       , version: Package.version
@@ -45,6 +44,7 @@ var recordOpt = new CLP.Option(["record"], "Records a new commit. Don't use this
       , authorsOpt
       , globalActivityOpt
       , configPathOpt
+      , firstDayOpt
     ])
   , options = null
   ;
@@ -94,6 +94,7 @@ if (authorsOpt.is_provided) {
     options.no_ansi = noAnsiOpt.is_provided;
     options.radius = (process.stdout.rows / 2) - 4;
 } else {
+    options.firstDay = firstDayOpt.value;
     options.theme = noAnsiOpt.is_provided ? null
                   : lightOpt.is_provided ? "LIGHT": "DARK"
                   ;

--- a/lib/index.js
+++ b/lib/index.js
@@ -298,6 +298,7 @@ GitStats.prototype.ansiCalendar = function (data, callback) {
             theme: data.theme
           , start: data.start
           , end: data.end
+          , firstDay: data.firstDay
         }));
     });
 


### PR DESCRIPTION
Fixes #18. Using `git-stats -d Mon` now sets the first day of the week to `Monday`. :dizzy: This doesn't really work because of [this issue](https://github.com/IonicaBizau/cli-gh-cal/issues/3).

However, please remember that [Sunday is the first day](https://www.biblegateway.com/passage/?search=Mark+16:9&version=NIV) while [Saturday is the 7th day of the week](https://www.biblegateway.com/passage/?search=Exodus+20%3A8-11&version=NIV) which is [holy](https://www.biblegateway.com/passage/?search=Genesis+2%3A2-3&version=NIV). Peace. :pray: 