### PR TITLE
New schema

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,63 @@
+## Migration
+
+This document contains information about how to smoothly
+migrate the things from a version to another version.
+
+
+### `1.x.x` to `2.x.x`
+
+The big change is the the data schema -- which should be migrated.
+
+The old `~/.git-stats` format was:
+
+```json
+{
+   "<date>": {
+      "<remote-url>": {
+          "<hash>": "<date>"
+      }
+   }
+}
+```
+
+In the new version, the remote url is not mandatory anymore. The new format is:
+
+```json
+{
+    "commits": {
+        "<date>": {
+            "<hash>": 1
+        }
+    }
+}
+```
+
+This is supposed to change when users install the `2.x.x` versions. However, if
+the migration script fails, you can always run it manually:
+
+```sh
+./scripts/migration/2.0.0.js
+```
+
+This will modify the `~/.git-stats` file.
+
+When using `git-stats` as library, things changed too. The old way was:
+
+```js
+var GitStats = require("git-stats");
+
+GitStats.ansiCalendar(opts, fn);
+```
+
+In `2.x.x` GitStats is a constructor. That allows us to create as many `git-stats`
+instances we want.
+
+```js
+var GitStats = require("git-stats");
+
+// Provide a custom data path
+var gs1 = new GitStats("path/to/some/data.json");
+
+// Use the default (~/.git-stats)
+var gs2 = new GitStats();
+```

--- a/bin/git-stats
+++ b/bin/git-stats
@@ -172,7 +172,6 @@ if (!authorsOpt.is_provided || globalActivityOpt.is_provided) {
     }
 }
 
-
 function display (err, data) {
     if (err) { return Logger.log(err, "error"); }
     process.stdout.write(data + "\n");

--- a/bin/git-stats
+++ b/bin/git-stats
@@ -160,8 +160,10 @@ if (!authorsOpt.is_provided || globalActivityOpt.is_provided) {
     // This can be a string or an object
     if (/^object|string$/.test(Typpy(GitStats.config.theme))) {
         options.theme = GitStats.config.theme;
-        if (!/^DARK|LIGHT$/.test(options.theme)) {
-            options.theme = null;
+        if (typeof GitStats.config.theme === "string") {
+            if (!/^DARK|LIGHT$/.test(options.theme)) {
+                options.theme = null;
+            }
         }
     } else {
         options.theme = noAnsiOpt.is_provided ? null

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,8 +24,15 @@ const DATE_FORMAT = "MMM D, YYYY"
       }
     ;
 
+/**
+ * GitStats
+ *
+ * @name GitStats
+ * @function
+ * @param {String} dataPath Path to the data file.
+ * @return {GitStats} The `GitStats` instance.
+ */
 function GitStats(dataPath) {
-    var self = this;
     this.path = Abs(Deffy(dataPath, DEFAULT_STORE));
 }
 
@@ -42,7 +49,7 @@ function GitStats(dataPath) {
  *  - `hash` (String): The commit hash.
  *
  * @param {Function} callback The callback function.
- * @return {GitStats} The `GitStats` object.
+ * @return {GitStats} The `GitStats` instance.
  */
 GitStats.prototype.record = function (data, callback) {
 
@@ -66,6 +73,8 @@ GitStats.prototype.record = function (data, callback) {
         return GitStats;
     }
 
+    // This is not used, but remains here just in case we need
+    // it in the future
     if (typeof data.url !== "string" || !data.url) {
         delete data.url;
     }
@@ -93,7 +102,7 @@ GitStats.prototype.record = function (data, callback) {
  * @name get
  * @function
  * @param {Function} callback The callback function.
- * @return {GitStats} The `GitStats` object.
+ * @return {GitStats} The `GitStats` instance.
  */
 GitStats.prototype.get = function (callback) {
     var self = this;
@@ -119,7 +128,7 @@ GitStats.prototype.get = function (callback) {
  * @function
  * @param {Object} stats The stats to be saved.
  * @param {Function} callback The callback function.
- * @return {GitStats} The `GitStats` object.
+ * @return {GitStats} The `GitStats` instance.
  */
 GitStats.prototype.save = function (stats, callback) {
     WriteJson(this.path, stats, callback);
@@ -139,7 +148,7 @@ GitStats.prototype.save = function (stats, callback) {
  *  - `format` (String): The format of the date (default: `"MMM D, YYYY"`).
  *
  * @param {Function} callback The callback function called with the current day formatted (type: string) and the `Moment` date object.
- * @return {GitStats} The `GitStats` object.
+ * @return {GitStats} The `GitStats` instance.
  */
 GitStats.prototype.iterateDays = function (data, callback) {
 
@@ -177,7 +186,7 @@ GitStats.prototype.iterateDays = function (data, callback) {
  * @function
  * @param {Object} data The object passed to the `iterateDays` method.
  * @param {Function} callback The callback function.
- * @return {GitStats} The `GitStats` object.
+ * @return {GitStats} The `GitStats` instance.
  */
 GitStats.prototype.graph = function (data, callback) {
 
@@ -219,7 +228,7 @@ GitStats.prototype.graph = function (data, callback) {
  * @function
  * @param {Object} data The object passed to the `graph` method.
  * @param {Function} callback The callback function.
- * @return {GitStats} The `GitStats` object.
+ * @return {GitStats} The `GitStats` instance.
  */
 GitStats.prototype.calendar = function (data, callback) {
 
@@ -275,7 +284,7 @@ GitStats.prototype.calendar = function (data, callback) {
  * @function
  * @param {Object} data The object passed to the `calendar` method.
  * @param {Function} callback The callback function.
- * @return {GitStats} The `GitStats` object.
+ * @return {GitStats} The `GitStats` instance.
  */
 GitStats.prototype.ansiCalendar = function (data, callback) {
 
@@ -306,6 +315,19 @@ GitStats.prototype.ansiCalendar = function (data, callback) {
     return self;
 };
 
+/**
+ * authors
+ * Creates an array with the authors of a git repository.
+ *
+ * @name authors
+ * @function
+ * @param {String|Object} options The repo path or an object containing the following fields:
+ *
+ *  - `repo` (String): The repository path.
+ *
+ * @param {Function} callback The callback function.
+ * @return {GitStats} The `GitStats` instance.
+ */
 GitStats.prototype.authors = function (options, callback) {
     var repo = new Gry(options.repo);
     repo.exec("shortlog -s -n --all", function (err, stdout) {
@@ -325,7 +347,23 @@ GitStats.prototype.authors = function (options, callback) {
     return this;
 };
 
+/**
+ * authorsPie
+ * Creates the authors pie.
+ *
+ * @name authorsPie
+ * @function
+ * @param {String|Object} options The repo path or an object containing the following fields:
+ *
+ *  - `repo` (String): The repository path.
+ *  - `radius` (Number): The pie radius.
+ *  - `no_ansi` (Boolean): If `true`, the pie will not contain ansi characters.
+ *
+ * @param {Function} callback The callback function.
+ * @return {GitStats} The `GitStats` instance.
+ */
 GitStats.prototype.authorsPie = function (options, callback) {
+
     if (typeof options === "string") {
         options = {
             repo: options
@@ -371,6 +409,22 @@ GitStats.prototype.authorsPie = function (options, callback) {
     return self;
 };
 
+/**
+ * globalActivity
+ * Creates the global contributions calendar (all commits made by all committers).
+ *
+ * @name globalActivity
+ * @function
+ * @param {String|Object} options The repo path or an object containing the following fields:
+ *
+ *  - `repo` (String): The repository path.
+ *  - `start` (String): The start date.
+ *  - `end` (String): The end date.
+ *  - `theme` (String|Object): The calendar theme.
+ *
+ * @param {Function} callback The callback function.
+ * @return {GitStats} The `GitStats` instance.
+ */
 GitStats.prototype.globalActivity = function (options, callback) {
 
     if (typeof options === "string") {

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,12 +14,14 @@ var Ul = require("ul")
   , Typpy = require("typpy")
   , Exec = ChildProcess.exec
   , Spawn = ChildProcess.spawn
-  , LowDb = require("lowdb")
   ;
 
 // Constants
 const DATE_FORMAT = "MMM D, YYYY"
     , DEFAULT_STORE = Abs("~/.git-stats")
+    , DEFAULT_DATA = {
+        commits: {}
+      }
     ;
 
 function GitStats(dataPath) {
@@ -65,20 +67,18 @@ GitStats.prototype.record = function (data, callback) {
     }
 
     if (typeof data.url !== "string" || !data.url) {
-        callback(new Error("Invalid url field. This commit is not recorded into the git-stats history since you haven't added the remote url. You can import the previous commits using the git-stats-importer tool."));
-        return GitStats;
+        delete data.url;
     }
 
     // Get stats
     self.get(function (err, stats) {
-        stats = stats || {};
 
-        var day = data.date.format(DATE_FORMAT)
-          , today = stats[day] = Object(stats[day])
-          , repo = today[data.url] = Object(today[data.url])
+        var commits = stats.commits
+          , day = data.date.format(DATE_FORMAT)
+          , today = commits[day] = Object(commits[day])
           ;
 
-        repo[data.hash] = { date: data.date };
+        today[data.hash] = 1;
 
         self.save(stats, callback);
     });
@@ -100,8 +100,8 @@ GitStats.prototype.get = function (callback) {
     ReadJson(self.path, function (err, data) {
 
         if (err && err.code === "ENOENT") {
-           return self.save({}, function (err) {
-               callback(err, {});
+           return self.save(DEFAULT_DATA, function (err) {
+               callback(err, DEFAULT_DATA);
            });
         }
 
@@ -198,14 +198,11 @@ GitStats.prototype.graph = function (data, callback) {
 
         // Iterate days
         self.iterateDays(data, function (cDay) {
+            cDayObj = Object(stats.commits[cDay]);
             cDayObj = year[cDay] = {
-                _: stats[cDay] || {}
-              , c: 0
+                _: cDayObj
+              , c: Object.keys(cDayObj).length
             };
-
-            Object.keys(cDayObj._).forEach(function (c) {
-                cDayObj.c += Object.keys(cDayObj._[c]).length;
-            });
         });
 
         callback(null, year);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "git-stats": "./bin/git-stats"
   },
   "scripts": {
-    "test": "node test"
+    "test": "node test",
+    "postinstall": "./scripts/migration/2.0.0.js"
   },
   "author": "Ionică Bizău <bizauionica@gmail.com>",
   "contributors": [

--- a/scripts/migration/2.0.0.js
+++ b/scripts/migration/2.0.0.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+// Dependencies
+var ReadJson = require("r-json")
+  , WriteJson = require("w-json")
+  , Abs = require("abs")
+  , Logger = require("bug-killer")
+  ;
+
+// Constants
+const DATA_FILE = Abs("~/.git-stats");
+
+function migrate() {
+    try {
+        var data = ReadJson(DATA_FILE)
+    } catch (e) {
+        if (e.code === "ENOENT") {
+            return;
+        }
+        Logger.log(e);
+    }
+
+    if (data.commits) {
+        return;
+    }
+
+    var newStats = { commits: {} };
+    Object.keys(data).forEach(function (day) {
+        var cDay = newStats.commits[day] = {};
+        Object.keys(data[day]).map(function (c) {
+            Object.keys(data[day][c]).map(function (h) {
+                cDay[h] = 1;
+            });
+        });
+    });
+
+    WriteJson(DATA_FILE, newStats);
+}
+
+migrate();


### PR DESCRIPTION
I simplified the things a lot. In this pull request I implemented the new schema which looks like this:

```json
{
    "commits": {
        "<date>": {
            "<hash>": 1
        }
    }
}
```

This means the remote url is not mandatory and not used anymore. Fixes #29 :tada:
I also added a migration guide (see `MIGRATION.md`) which contains instructions how to migrate to `2.x.x`. Usually, the migration should be made automatically using the migration script on `npm install`, but things can always crash, so a migration guide is always useful. :smile: :memo: 

This fixes #38.