### PR TITLE
Script

### DIFF
--- a/.blah/README.ejs
+++ b/.blah/README.ejs
@@ -73,7 +73,7 @@ Then, run `<%- _.pack.name %> --help` and see what the cli tool can do.
 
 
 ```sh
-$ git-stats --help
+$ git-stats -h
 Usage: git-stats [options]
 
 Options:
@@ -90,6 +90,7 @@ Options:
   --record <data>        Records a new commit. Don't use this unless you
                          are a mad scientist. If you are a developer, just
                          use this option as part of the module.
+  -r, --raw              Outputs a dump of the raw JSON data.
   -h, --help             Displays this help.
   -v, --version          Displays version information.
 

--- a/.blah/README.ejs
+++ b/.blah/README.ejs
@@ -232,6 +232,9 @@ For full API reference, see the [DOCUMENTATION.md][docs] file.
 <%- docs %>
 <% } %>
 
+## Press Highlights
+ - [*A GitHub-like contributions calendar, but locally, with all your git commits*, The Changelog](https://changelog.com/github-like-contributions-calendar-locally-git-commits/)
+
 <% // How to contribute %>
 ## How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].

--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ g1.ansiCalendar({
 
 For full API reference, see the [DOCUMENTATION.md][docs] file.
 
+## Press Highlights
+ - [*A GitHub-like contributions calendar, but locally, with all your git commits*, The Changelog](https://changelog.com/github-like-contributions-calendar-locally-git-commits/)
+
 ## How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ curl -s https://raw.githubusercontent.com/IonicaBizau/git-stats/master/scripts/i
 Then, run `git-stats --help` and see what the cli tool can do.
 
 ```sh
-$ git-stats --help
+$ git-stats -h
 Usage: git-stats [options]
 
 Options:
@@ -65,6 +65,7 @@ Options:
   --record <data>        Records a new commit. Don't use this unless you
                          are a mad scientist. If you are a developer, just
                          use this option as part of the module.
+  -r, --raw              Outputs a dump of the raw JSON data.
   -h, --help             Displays this help.
   -v, --version          Displays version information.
 

--- a/bin/git-stats
+++ b/bin/git-stats
@@ -63,6 +63,7 @@ var recordOpt = new Clp.Option(["record"], "Records a new commit. Don't use this
       , dataPathOpt
       , firstDayOpt
       , recordOpt
+      , rawOpt
     ])
   , options = null
   ;
@@ -148,6 +149,9 @@ if (!authorsOpt.is_provided || globalActivityOpt.is_provided) {
 
 function display (err, data) {
     if (err) { return Logger.log(err, "error"); }
+    if (typeof data !== "string") {
+        data = JSON.stringify(data);
+    }
     process.stdout.write(data + "\n");
 }
 

--- a/bin/git-stats
+++ b/bin/git-stats
@@ -39,6 +39,7 @@ var recordOpt = new Clp.Option(["record"], "Records a new commit. Don't use this
   , dataPathOpt = new Clp.Option(["d", "data"], "Sets a custom data store file.", "path", GitStats.config.path)
   , globalActivityOpt = new Clp.Option(["g", "global-activity"], "Shows global activity calendar in the current repository.")
   , firstDayOpt = new Clp.Option(["f", "first-day"], "Sets the first day of the week.", "day", GitStats.config.first_day)
+  , rawOpt = new Clp.Option(["r", "raw"], "Outputs a dump of the raw JSON data.")
   , parser = new Clp({
         name: "Git Stats"
       , version: Package.version
@@ -102,6 +103,7 @@ if (recordOpt.is_provided) {
 options = {
     start: sinceDateOpt.value ? Moment(sinceDateOpt.value) : Moment().subtract(1, "years")
   , end: untilDateOpt.value ? Moment(untilDateOpt.value) : Moment()
+  , raw: rawOpt.is_provided
 };
 
 // Validate the dates
@@ -152,6 +154,7 @@ function display (err, data) {
 if (globalActivityOpt.is_provided) {
     return GitStats.globalActivity(options, display);
 }
+
 
 // Show the graphs
 GitStats[authorsOpt.is_provided ? "authorsPie" : "ansiCalendar"](options, display);

--- a/lib/index.js
+++ b/lib/index.js
@@ -459,34 +459,38 @@ GitStats.prototype.calendar = function (data, callback) {
  *
  * @name ansiCalendar
  * @function
- * @param {Object} data The object passed to the `calendar` method.
+ * @param {Object} options The object passed to the `calendar` method.
  * @param {Function} callback The callback function.
  * @return {GitStats} The `GitStats` instance.
  */
-GitStats.prototype.ansiCalendar = function (data, callback) {
+GitStats.prototype.ansiCalendar = function (options, callback) {
 
-    if (typeof data === "function") {
-        callback = data;
-        data = undefined;
+    if (typeof options === "function") {
+        callback = options;
+        options = undefined;
     }
 
     var self = this;
 
-    self.graph(data, function (err, graph) {
-        var cal = [];
+    self.graph(options, function (err, graph) {
+        var cal = []
+          , data = {
+                theme: options.theme
+              , start: options.start
+              , end: options.end
+              , firstDay: options.firstDay
+              , cal: cal
+            }
+          ;
 
-        self.iterateDays(data, function (cDay) {
+        self.iterateDays(options, function (cDay) {
             cDayObj = graph[cDay];
             if (!cDayObj) { return; }
             cal.push([cDay, cDayObj.c]);
         });
 
-        callback(null, CliGhCal(cal, {
-            theme: data.theme
-          , start: data.start
-          , end: data.end
-          , firstDay: data.firstDay
-        }));
+
+        callback(null, options.raw ? data : CliGhCal(cal, data));
     });
 
     return self;
@@ -535,6 +539,7 @@ GitStats.prototype.authors = function (options, callback) {
  *  - `repo` (String): The repository path.
  *  - `radius` (Number): The pie radius.
  *  - `no_ansi` (Boolean): If `true`, the pie will not contain ansi characters.
+ *  - `raw` (Boolean): If `true`, the raw JSON will be displayed.
  *
  * @param {Function} callback The callback function.
  * @return {GitStats} The `GitStats` instance.
@@ -574,13 +579,14 @@ GitStats.prototype.authorsPie = function (options, callback) {
             authors.push(others);
         }
 
-        pie = new CliPie(options.radius, authors, {
+        var data = {
             legend: true
           , flat: true
           , no_ansi: options.no_ansi
-        });
+          , authors: authors
+        };
 
-        callback(null, pie.toString());
+        callback(null, options.raw ? data : new CliPie(options.radius, authors, data).toString());
     });
 
     return self;
@@ -598,6 +604,7 @@ GitStats.prototype.authorsPie = function (options, callback) {
  *  - `start` (String): The start date.
  *  - `end` (String): The end date.
  *  - `theme` (String|Object): The calendar theme.
+ *  - `raw` (Boolean): If `true`, the raw JSON will be displayed.
  *
  * @param {Function} callback The callback function.
  * @return {GitStats} The `GitStats` instance.
@@ -632,11 +639,13 @@ GitStats.prototype.globalActivity = function (options, callback) {
         Object.keys(commits).forEach(function (c) {
             cal.push([c, commits[c]])
         });
-        callback(null, CliGhCal(cal, {
+        var data = {
             theme: options.theme
           , start: options.start
           , end: options.end
-        }));
+          , cal: cal
+        };
+        callback(null, options.raw ? data : CliGhCal(cal, data));
     });
 
     return this;

--- a/lib/index.js
+++ b/lib/index.js
@@ -245,7 +245,6 @@ GitStats.prototype.removeCommit = function (data, callback) {
 
         if (err) { return callback(err); }
         if (!data.date) {
-            debugger
             IterateObject(stats.commits, function (todayObj) {
                 delete todayObj[data.hash];
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ var Ul = require("ul")
   , Typpy = require("typpy")
   , Exec = ChildProcess.exec
   , Spawn = ChildProcess.spawn
+  , IterateObject = require("iterate-object")
   ;
 
 // Constants
@@ -209,7 +210,7 @@ GitStats.prototype.record = function (data, callback) {
  * @function
  * @param {Object} data The commit data containing:
  *
- *  - `date` (String|Date): The date object or a string in a format that can be parsed.
+ *  - `date` (String|Date): The date object or a string in a format that can be parsed. If not provided, the hash object will be searched in all dates.
  *  - `hash` (String): The commit hash.
  *  - `_data` (Object): If this field is provided, it should be the content of the git-stats data file as object. It will be modified in-memory and then returned.
  *  - `save` (Boolean): If `false`, the result will *not* be saved in the file.
@@ -230,8 +231,7 @@ GitStats.prototype.removeCommit = function (data, callback) {
     }
 
     if (!/^moment|date$/.test(Typpy(data.date))) {
-        callback(new Error("The date field should be a string or a date object."));
-        return GitStats;
+        data.date = null;
     } else if (Typpy(data.date, Date)) {
         data.date = Moment(data.date);
     }
@@ -244,13 +244,19 @@ GitStats.prototype.removeCommit = function (data, callback) {
     function modify (err, stats) {
 
         if (err) { return callback(err); }
+        if (!data.date) {
+            debugger
+            IterateObject(stats.commits, function (todayObj) {
+                delete todayObj[data.hash];
+            });
+        } else {
+            var commits = stats.commits
+              , day = data.date.format(DATE_FORMAT)
+              , today = commits[day] = Object(commits[day])
+              ;
 
-        var commits = stats.commits
-          , day = data.date.format(DATE_FORMAT)
-          , today = commits[day] = Object(commits[day])
-          ;
-
-        delete today[data.hash];
+            delete today[data.hash];
+        }
 
         if (data.save === false) {
             callback(null, stats);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-stats",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Local git statistics including GitHub-like contributions calendars.",
   "main": "lib/index.js",
   "bin": {
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "node test",
-    "postinstall": "./scripts/migration/2.0.0.js"
+    "postinstall": "node scripts/migration/2.0.0.js"
   },
   "author": "Ionică Bizău <bizauionica@gmail.com>",
   "contributors": [


### PR DESCRIPTION
 - Use `node path/to/migration-script.js` instead of `./path/to/...` to be compatible with Windows.
 - Added the `--raw` option which dumps the raw json.
 - Improved the `removeCommit` method (the `date` is not mandatory anymore).