### PR TITLE
Fixed the getConfig callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,6 +87,9 @@ GitStats.prototype.getConfig = function (callback) {
         }
         return {};
     }
+    if (callback) {
+        callback(null, data);
+    }
     return data;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-stats",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Local git statistics including GitHub-like contributions calendars.",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-stats",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Local git statistics including GitHub-like contributions calendars.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
`getConfig` is a sync method, but still accepts a callback function as legacy feature.
The callback handler was not triggered when the result was successful. That would [break the `git-stats-importer` functionality](https://github.com/IonicaBizau/git-stats-importer/issues/32).