### PR TITLE
git-stats 2.9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ I'd be curious to see your calendar with all your commits. Ping me on Twitter ([
 
 You can install the package globally and use it as command line tool:
 
-```sh
+
+    ```sh
 # Install the package globally
 npm i -g git-stats
 # Initialize git hooks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-stats",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Local git statistics including GitHub-like contributions calendars.",
   "main": "lib/index.js",
   "bin": {
@@ -241,6 +241,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
Fix #83. Whitelist the scripts directory.