### PR TITLE
git-stats 2.9.8

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -528,7 +528,7 @@ GitStats.prototype.authors = function (options, callback) {
     var repo = new Gry(options.repo);
     repo.exec("shortlog -s -n --all", function (err, stdout) {
         if (err) { return callback(err); }
-        lines = stdout.split("\n");
+        var lines = stdout.split("\n");
         pieData = stdout.split("\n").map(function (c) {
             var splits = c.split("\t").map(function (cc) {
                 return cc.trim();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-stats",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "description": "Local git statistics including GitHub-like contributions calendars.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
Fixed #92. Define the `lines` variable.