### PR TITLE
IsThere missing when using`-d` modifier

### DIFF
--- a/bin/git-stats
+++ b/bin/git-stats
@@ -10,6 +10,7 @@ const Tilda = require("tilda")
     , Typpy = require("typpy")
     , Package = require("../package")
     , ReadJson = require("r-json")
+    , IsThere = require("is-there")
     ;
 
 // Constants


### PR DESCRIPTION
When running `git-stats -d` is breaks on a missing import.

```
$ git-stats -d repositories/cadexmus2
/var/www/html/node_modules/git-stats/bin/git-stats:104
        if (!IsThere(GitStats.path)) {
             ^

ReferenceError: IsThere is not defined
```

Cheers,