### PR TITLE
readme: simplify config syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,29 +201,29 @@ This file should export an object, like below (defaults are listed):
 ```js
 module.exports = {
     // "DARK", "LIGHT" or an object interpreted by IonicaBizau/node-git-stats-colors
-    "theme": "DARK"
+    theme: "DARK",
 
     // The file where the commit hashes will be stored
-  , "path": "~/.git-stats"
+    path: "~/.git-stats",
 
     // First day of the week
-  , first_day: "Sun"
+    first_day: "Sun",
 
     // This defaults to *one year ago*
     // It can be any parsable date
-  , since: undefined
+    since: undefined,
 
     // This defaults to *now*
     // It can be any parsable date
-  , until: undefined
+    until: undefined,
 
     // Don't show authors by default
     // If true, this will enable the authors pie
-  , authors: false
+    authors: false,
 
     // No global activity by default
     // If true, this will enable the global activity calendar in the current project
-  , global_activity: false
+    global_activity: false,
 };
 ```
 


### PR DESCRIPTION
I can't tell if this is by accident or personal preference, but this "coding style" goes against all rules of modern JavaScript. Please allow me to change this snippet to use a more conventional style. 🙂