### PR TITLE
git-stats 3.1.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -560,15 +560,16 @@ class GitStats {
           ;
 
         self.authors(options, function (err, authors) {
+            const maxAuthors = 2 * options.radius;
             if (err) { return callback(err); }
-            if (authors.length > 50) {
+            if (authors.length > maxAuthors) {
                 let others = {
-                    value: authors.slice(50).reduce(function (a, b) {
+                    value: authors.slice(maxAuthors).reduce(function (a, b) {
                         return a + b.value;
                     }, 0)
                   , label: "Others"
                 };
-                authors = authors.slice(0, 50);
+                authors = authors.slice(0, maxAuthors);
                 authors.push(others);
             }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-stats",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "git-stats",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "git-stats": "bin/git-stats"
   },
   "name": "git-stats",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Local git statistics including GitHub-like contributions calendars.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "contributors": [
     "Gnab <as0n@gnab.fr>",
     "William Boman <william@redwill.se>",
-    "Fabian Furger <mystyfly@gmail.com>"
+    "Fabian Furger <mystyfly@gmail.com>",
+    "Jonah Lawrence <jonah@freshidea.com>"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
fix: Display top contributors correctly when larger than chart #182, thanks @DenverCoder1! :cake: