### PR TITLE
use ISO8601 date format in post-commit hook

### DIFF
--- a/scripts/init-git-post-commit
+++ b/scripts/init-git-post-commit
@@ -29,7 +29,7 @@ hook=$(cat <<EOF
 # Copy last commit hash to clipboard on commit
 commit_hash=\$(git rev-parse HEAD)
 repo_url=\$(git config --get remote.origin.url)
-commit_date=\$(git log -1 --format=%cd)
+commit_date=\$(git log -1 --format=%cI)
 commit_data="\"{ \"date\": \"\$commit_date\", \"url\": \"\$repo_url\", \"hash\": \"\$commit_hash\" }\""
 git-stats --record "\${commit_data}"
 ### git-stats hook (end) ###


### PR DESCRIPTION
The post-commit hook previously used `git log -1 --format=%cd` to record commit dates,
which produced date strings that were not reliably parsed by JavaScript's Date constructor.
This caused imported commits to be grouped under "Invalid date" in .git-stats.
This commit changes the format string to `%cI`, ensuring all dates are output in ISO8601 format and parsed correctly.

---

bug reproduce:


<img width="1751" alt="image" src="https://github.com/user-attachments/assets/510342a7-7fc7-4a69-b131-965beba61fc5" />

```bash
$ [[ -f ~/.git-stats ]] && rm -rf ~/.git-stats; bash .git/hooks/post-commit; head ~/.git-stats
{
  "commits": {
    "Invalid date": {
      "ddc04b5316f82172edbb2b1d86315ab2a6accc3e": 1
    }
  }
}

$ commit_date=$(git log -1 --format=%cd) && echo "${commit_date}"
2025-07-01 20:41:37 -0700 Tuesday

$ node -p "new Date('${commit_date}')"
Invalid Date
```

---

solution

```
$ commit_date=$(git log -1 --format=%cI) && echo "${commit_date}"
2025-07-01T20:41:37-07:00

$ node -p "new Date('${commit_date}')"
2025-07-02T03:41:37.000Z
```

<img width="1750" alt="image" src="https://github.com/user-attachments/assets/efe4490d-fb8b-408a-8572-cc9297e347d7" />

---

verification


<img width="1749" alt="image" src="https://github.com/user-attachments/assets/cfff667d-7190-4614-83d3-8d271980ca13" />


---

environment:

```
$ git --version
git version 2.50.0.dirty

$ node --version
v23.11.0
```