### PR TITLE
Add author additions/deletions statistics feature

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -158,6 +158,39 @@ Creates the authors pie.
 #### Return
 - **GitStats** The `GitStats` instance.
 
+### `authorsStats(options, callback)`
+Creates an array with the authors and their additions/deletions statistics.
+
+#### Params
+
+- **String|Object** `options`: The repo path or an object containing the following fields:
+ - `repo` (String): The repository path.
+ - `start` (String): The start date.
+ - `end` (String): The end date.
+ - `mode` (String): 'additions', 'deletions', or 'both' (default: 'both').
+- **Function** `callback`: The callback function.
+
+#### Return
+- **GitStats** The `GitStats` instance.
+
+### `authorsStatsPie(options, callback)`
+Creates a pie chart showing author statistics (additions/deletions).
+
+#### Params
+
+- **String|Object** `options`: The repo path or an object containing the following fields:
+ - `repo` (String): The repository path.
+ - `start` (String): The start date.
+ - `end` (String): The end date.
+ - `mode` (String): 'additions', 'deletions', or 'both' (default: 'both').
+ - `radius` (Number): The pie radius.
+ - `no_ansi` (Boolean): If `true`, the pie will not contain ansi characters.
+ - `raw` (Boolean): If `true`, the raw JSON will be displayed.
+- **Function** `callback`: The callback function.
+
+#### Return
+- **GitStats** The `GitStats` instance.
+
 ### `globalActivity(options, callback)`
 Creates the global contributions calendar (all commits made by all committers).
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Options:
                          repository.
   -a, --authors          Shows a pie chart with the author related
                          contributions in the current repository.
+  -S, --author-stats     Shows a pie chart with author additions/deletions
+                         statistics.
+  -M, --stats-mode <mode> Mode for author stats: 'additions', 'deletions', or
+                         'both' (default: 'both').
   -u, --until <date>     Optional end date.
   -s, --since <date>     Optional start date.
   --record <data>        Records a new commit. Don't use this unless you are
@@ -116,6 +120,9 @@ Examples:
   $ git-stats -l # Light mode
   $ git-stats -s '1 January, 2012' # All the commits from 1 January 2012 to now
   $ git-stats -s '1 January, 2012' -u '31 December, 2012' # All the commits from 2012
+  $ git-stats -S # Shows author additions/deletions statistics pie chart
+  $ git-stats -S -M additions # Shows only additions statistics
+  $ git-stats -S -M deletions # Shows only deletions statistics
 
 Your commit history is kept in ~/.git-stats by default. You can create
 ~/.git-stats-config.js to specify different defaults.

--- a/bin/git-stats
+++ b/bin/git-stats
@@ -59,6 +59,16 @@ new Tilda(`${__dirname}/../package.json`, {
           , desc: "Filter author related contributions in the current repository."
         }
       , {
+            opts: ["S", "author-stats"]
+          , desc: "Shows a pie chart with author additions/deletions statistics."
+        }
+      , {
+            opts: ["M", "stats-mode"]
+          , desc: "Mode for author stats: 'additions', 'deletions', or 'both' (default: 'both')."
+          , name: "mode"
+          , default: "both"
+        }
+      , {
             opts: ["n", "disable-ansi"]
           , desc: "Forces the tool not to use ANSI styles."
         }
@@ -86,6 +96,9 @@ new Tilda(`${__dirname}/../package.json`, {
       , "git-stats -l # Light mode"
       , "git-stats -s '1 January, 2012' # All the commits from 1 January 2012 to now"
       , "git-stats -s '1 January, 2012' -u '31 December, 2012' # All the commits from 2012"
+      , "git-stats -S # Shows author additions/deletions statistics pie chart"
+      , "git-stats -S -M additions # Shows only additions statistics"
+      , "git-stats -S -M deletions # Shows only deletions statistics"
     ]
   , notes: "Your commit history is kept in ~/.git-stats by default. You can create ~/.git-stats-config.js to specify different defaults."
 }).main(action => {
@@ -100,6 +113,8 @@ new Tilda(`${__dirname}/../package.json`, {
       , globalActivityOpt = action.options.globalActivity
       , rawOpt = action.options.raw
       , authorOpt = action.options.author
+      , authorStatsOpt = action.options.authorStats
+      , statsModeOpt = action.options.statsMode
       ;
 
     let options = {};
@@ -162,7 +177,7 @@ new Tilda(`${__dirname}/../package.json`, {
     }
 
     // Add the repo path
-    if (authorsOpt.is_provided || globalActivityOpt.is_provided) {
+    if (authorsOpt.is_provided || globalActivityOpt.is_provided || authorStatsOpt.is_provided) {
         options.repo = process.cwd();
     }
 
@@ -177,7 +192,14 @@ new Tilda(`${__dirname}/../package.json`, {
         options.radius = (process.stdout.rows / 2) - 4;
     }
 
-    if (!authorsOpt.is_provided || globalActivityOpt.is_provided) {
+    // Handle author stats
+    if (authorStatsOpt.is_provided) {
+        options.no_ansi = noAnsiOpt.is_provided;
+        options.radius = (process.stdout.rows / 2) - 4;
+        options.mode = statsModeOpt.value || 'both';
+    }
+
+    if (!authorsOpt.is_provided && !authorStatsOpt.is_provided || globalActivityOpt.is_provided) {
         // This can be a string or an object
         if (/^object|string$/.test(Typpy(GitStats.config.theme)) && !noAnsiOpt.is_provided && !lightOpt.is_provided) {
             options.theme = GitStats.config.theme;
@@ -203,6 +225,10 @@ new Tilda(`${__dirname}/../package.json`, {
 
     if (globalActivityOpt.is_provided) {
         return GitStats.globalActivity(options, display);
+    }
+
+    if (authorStatsOpt.is_provided) {
+        return GitStats.authorsStatsPie(options, display);
     }
 
     // Show the graphs

--- a/example/author-stats.js
+++ b/example/author-stats.js
@@ -1,0 +1,46 @@
+// Dependencies
+const GitStats = require("../lib");
+
+// Create the GitStats instance
+const g1 = new GitStats();
+
+console.log("Author Statistics Examples:\n");
+
+// Display author statistics (both additions and deletions)
+console.log("1. Author statistics (additions + deletions):");
+g1.authorsStatsPie({
+    repo: process.cwd(),
+    mode: "both"
+}, function (err, data) {
+    console.log(err || data);
+    console.log("\n" + "=".repeat(50) + "\n");
+
+    // Display only additions
+    console.log("2. Author statistics (additions only):");
+    g1.authorsStatsPie({
+        repo: process.cwd(),
+        mode: "additions"
+    }, function (err, data) {
+        console.log(err || data);
+        console.log("\n" + "=".repeat(50) + "\n");
+
+        // Display only deletions
+        console.log("3. Author statistics (deletions only):");
+        g1.authorsStatsPie({
+            repo: process.cwd(),
+            mode: "deletions"
+        }, function (err, data) {
+            console.log(err || data);
+            console.log("\n" + "=".repeat(50) + "\n");
+
+            // Display raw JSON data
+            console.log("4. Raw JSON data:");
+            g1.authorsStats({
+                repo: process.cwd(),
+                mode: "both"
+            }, function (err, data) {
+                console.log(err || JSON.stringify(data, null, 2));
+            });
+        });
+    });
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -613,6 +613,172 @@ class GitStats {
     }
 
     /**
+     * authorsStats
+     * Creates an array with the authors and their additions/deletions statistics.
+     *
+     * @name authorsStats
+     * @function
+     * @param {String|Object} options The repo path or an object containing the following fields:
+     *
+     *  - `repo` (String): The repository path.
+     *  - `start` (String): The start date.
+     *  - `end` (String): The end date.
+     *  - `mode` (String): 'additions', 'deletions', or 'both' (default: 'both').
+     *
+     * @param {Function} callback The callback function.
+     * @return {GitStats} The `GitStats` instance.
+     */
+    authorsStats(options, callback) {
+        if (typeof options === "string") {
+            options = {
+                repo: options
+            };
+        }
+
+        // Set default dates if not provided
+        options = Ul.merge(options, {
+            start: options.start || Moment().subtract(1, "years"),
+            end: options.end || Moment()
+        });
+
+        const repo = new Gry(options.repo);
+        const mode = options.mode || 'both';
+        
+        // Use git log with --numstat to get additions and deletions
+        repo.exec(['log', '--pretty=format:%aN', '--numstat', '--since', options.start.toString(), '--until', options.end.toString()], function (err, stdout) {
+            if (err) {
+                return callback(err);
+            }
+            
+            const lines = stdout.split('\n');
+            const authorStats = {};
+            let currentAuthor = null;
+            
+            lines.forEach(function(line) {
+                line = line.trim();
+                if (!line) return;
+                
+                // Check if this line is an author name (doesn't start with numbers)
+                if (!/^\d/.test(line)) {
+                    currentAuthor = line;
+                    if (!authorStats[currentAuthor]) {
+                        authorStats[currentAuthor] = { additions: 0, deletions: 0 };
+                    }
+                } else if (currentAuthor) {
+                    // This is a numstat line (additions, deletions, filename)
+                    const parts = line.split('\t');
+                    if (parts.length >= 2) {
+                        const additions = parseInt(parts[0]) || 0;
+                        const deletions = parseInt(parts[1]) || 0;
+                        authorStats[currentAuthor].additions += additions;
+                        authorStats[currentAuthor].deletions += deletions;
+                    }
+                }
+            });
+            
+            // Convert to array format and sort by the requested metric
+            const result = Object.keys(authorStats).map(function(author) {
+                const stats = authorStats[author];
+                let value;
+                let label = author;
+                
+                if (mode === 'additions') {
+                    value = stats.additions;
+                    label += ` (+${stats.additions})`;
+                } else if (mode === 'deletions') {
+                    value = stats.deletions;
+                    label += ` (-${stats.deletions})`;
+                } else {
+                    value = stats.additions + stats.deletions;
+                    label += ` (+${stats.additions}/-${stats.deletions})`;
+                }
+                
+                return {
+                    value: value,
+                    label: label,
+                    author: author,
+                    additions: stats.additions,
+                    deletions: stats.deletions
+                };
+            }).filter(function(item) {
+                return item.value > 0;
+            }).sort(function(a, b) {
+                return b.value - a.value;
+            });
+            
+            callback(null, result);
+        });
+        return this;
+    }
+
+    /**
+     * authorsStatsPie
+     * Creates a pie chart showing author statistics (additions/deletions).
+     *
+     * @name authorsStatsPie
+     * @function
+     * @param {String|Object} options The repo path or an object containing the following fields:
+     *
+     *  - `repo` (String): The repository path.
+     *  - `start` (String): The start date.
+     *  - `end` (String): The end date.
+     *  - `mode` (String): 'additions', 'deletions', or 'both' (default: 'both').
+     *  - `radius` (Number): The pie radius.
+     *  - `no_ansi` (Boolean): If `true`, the pie will not contain ansi characters.
+     *  - `raw` (Boolean): If `true`, the raw JSON will be displayed.
+     *
+     * @param {Function} callback The callback function.
+     * @return {GitStats} The `GitStats` instance.
+     */
+    authorsStatsPie(options, callback) {
+        if (typeof options === "string") {
+            options = {
+                repo: options
+            };
+        }
+
+        options = Ul.merge(options, {
+            radius: process.stdout.rows / 2 || 20,
+            mode: 'both'
+        });
+
+        if (!IsThere(options.repo)) {
+            return callback(new Error("The repository folder doesn't exist."));
+        }
+
+        let self = this;
+
+        self.authorsStats(options, function (err, authors) {
+            if (err) {
+                return callback(err);
+            }
+
+            const maxAuthors = 2 * options.radius;
+            if (authors.length > maxAuthors) {
+                let others = {
+                    value: authors.slice(maxAuthors).reduce(function (a, b) {
+                        return a + b.value;
+                    }, 0),
+                    label: "Others"
+                };
+                authors = authors.slice(0, maxAuthors);
+                authors.push(others);
+            }
+
+            let data = {
+                legend: true,
+                flat: true,
+                no_ansi: options.no_ansi,
+                authors: authors
+            };
+
+            callback(null, options.raw ? data : new CliPie(options.radius, authors, data).toString());
+        });
+
+        return self;
+    }
+
+    /**
      * globalActivity
      * Creates the global contributions calendar (all commits made by all committers).
      *


### PR DESCRIPTION
- Add authorsStats() method to get additions/deletions data per author
- Add authorsStatsPie() method to display stats as pie chart
- Add CLI options -S/--author-stats and -M/--stats-mode
- Support three modes: 'additions', 'deletions', 'both' (default)
- Update documentation and examples
- Add example/author-stats.js to demonstrate usage

Fixes #128