### PR TITLE
Added author filter for global activity #202

### DIFF
--- a/bin/git-stats
+++ b/bin/git-stats
@@ -111,6 +111,7 @@ new Tilda(`${__dirname}/../package.json`, {
       , lightOpt = action.options.light
       , dataPathOpt = action.options.data
       , globalActivityOpt = action.options.globalActivity
+
       , rawOpt = action.options.raw
       , authorOpt = action.options.author
       , authorStatsOpt = action.options.authorStats


### PR DESCRIPTION
This PR adds the --author filter to the global activity calendar as requested in issue #202. Closes #202.